### PR TITLE
Fix for JSIP-519: OriginFieldParser skips session id and session version

### DIFF
--- a/src/gov/nist/javax/sdp/parser/OriginFieldParser.java
+++ b/src/gov/nist/javax/sdp/parser/OriginFieldParser.java
@@ -59,11 +59,11 @@ public class OriginFieldParser extends SDPParser {
             Token sessionId = lexer.getNextToken();
             // guard against very long session IDs
             String sessId = sessionId.getTokenValue();
-            if (sessId.length() > 18)
-                sessId = sessId.substring(sessId.length() - 18);
             try {
                 originField.setSessId(Long.parseLong(sessId));
             } catch (NumberFormatException ex) {
+                if (sessId.length() > 18)
+                    sessId = sessId.substring(sessId.length() - 18);
                 originField.setSessionId(sessId);
             }
             this.lexer.SPorHT();
@@ -72,11 +72,11 @@ public class OriginFieldParser extends SDPParser {
             Token sessionVersion = lexer.getNextToken();
             // guard against very long session Verion
             String sessVer = sessionVersion.getTokenValue();
-            if (sessVer.length() > 18)
-                sessVer = sessVer.substring(sessVer.length() - 18);
             try {
                 originField.setSessVersion(Long.parseLong(sessVer));
             } catch (NumberFormatException ex) {
+                if (sessVer.length() > 18)
+                    sessVer = sessVer.substring(sessVer.length() - 18);
                 originField.setSessVersion(sessVer);
 
             }


### PR DESCRIPTION
This change cherry-pick fix for a truncation of session `ID` when `SDP` from `Chromium` parsed, for example session `ID = 5300496626819977905` fits `long`, but it is truncated when text `SDP` is parsed to `SesssionDescription` and converted back to text. So `ID` after truncation is `300496626819977905`.
Would be nice to have the issue fixed in this fork. 